### PR TITLE
add basic leak detection based on continuous flow

### DIFF
--- a/flumeDevice
+++ b/flumeDevice
@@ -40,15 +40,18 @@ metadata
         command "setAwayMode"
         command "clearAwayMode"
         command "clearWetStatus"
-        
+        command "testWetStatus"
+
         attribute "commStatus", "string"
-        
+
         attribute "usageLastMinute", "number"
         attribute "usageLastHour", "number"
         attribute "usageLastDay", "number"
         attribute "usageLastWeek", "number"
         attribute "usageLastMonth", "number"
-        
+
+        attribute "continuousFlowReadings", "number"
+
         attribute "notificationStream", "string"
     }
 }
@@ -66,11 +69,19 @@ preferences
     {
         input name: "slidingWindow", type: "bool", title: "Use sliding time windows for usage? (turn off to mirror behavior in Flume app)", defaultValue: false
         input "refreshInterval", "number", title: "Refresh interval (minutes)", defaultValue: 2, required: true
+    }
+    section
+    {
+        input "flowAlarmTrigger", "number", title: "Continual readings to trigger alarm. '0' disables trigger.  The lapsed time before alert will be (Refresh Interval) * ThisValue", defaultValue: 45, required: true
+        input "flowAlarmLookback", "number", title: "Number of minutes to look back to indicated flow occurred.", defaultValue: 5, required: true
+    }
+    section
+    {
         input name: "logEnable", type: "bool", title: "Enable debug logging", defaultValue: false
     }
 }
 
-def logDebug(msg) 
+def logDebug(msg)
 {
     if (logEnable)
     {
@@ -86,28 +97,28 @@ def updated()
 def configure()
 {
     sendEvent(name: "commStatus", value: "unknown")
-    
+
     try
     {
         state.clear()
-        
+
         getTokens()
         fetchDevices()
         fetchLocations()
-        
+
         setAlertCount(0)
-        
+
         initialize(false)
-        
+
         sendEvent(name: "commStatus", value: "good")
     }
     catch (Exception e)
     {
         logDebug("error: ${e.message}")
         //logDebug("status = ${e.getResponse()?.getStatus()}")
-        
+
         sendEvent(name: "commStatus", value: "error")
-    }    
+    }
 }
 
 def initialize()
@@ -121,9 +132,9 @@ def initialize(doGetTokens)
     {
         getTokens()
     }
-        
+
     clearWetStatus()
-    refresh()    
+    refresh()
 }
 
 def refresh()
@@ -131,22 +142,22 @@ def refresh()
     try
     {
         unschedule(refresh)
-        
+
         queryDevice()
         fetchUsageAlerts()
         fetchNotifications()
         fetchLocations()
-        
+
         sendEvent(name: "commStatus", value: "good")
     }
     catch (Exception e)
     {
-        logDebug("error: ${e.message}")
-        //logDebug("status = ${e.getResponse()?.getStatus()}")
-        
+        log.error("error: ${e.message}")
+        //log.error("status = ${e.getResponse()?.getStatus()}")
+
         sendEvent(name: "commStatus", value: "error")
     }
-    
+
     // always schedule next refresh
     runIn((60 * refreshInterval).toFloat().toInteger(), refresh)
 }
@@ -155,7 +166,7 @@ def getTokens()
 {
     def resp = httpExec("POST", genParamsTokens("get"), true)?.data
     logDebug("getTokens resp = ${resp}")
-    
+
     updateAuthTokensStore(resp)
 }
 
@@ -163,8 +174,8 @@ def refreshTokens()
 {
     def resp = httpExec("POST", genParamsTokens("refresh"), true)?.data
     logDebug("refreshTokens resp = ${resp}")
-    
-    updateAuthTokensStore(resp)    
+
+    updateAuthTokensStore(resp)
 }
 
 def fetchDevices()
@@ -172,7 +183,7 @@ def fetchDevices()
     def queryString = "?user=false&location=false"
     def resp = httpExec("GET", genParamsMain("users/${getUserId()}/devices/${queryString}"), true)?.data
     logDebug("fetchDevices resp = ${resp}")
-    
+
     if(resp)
     {
         setDevices(resp.data)
@@ -184,7 +195,7 @@ def fetchLocations()
     def queryString = "?limit=50&offset=0&sort_field=id&sort_direction=ASC&list_shared=false"
     def resp = httpExec("GET", genParamsMain("users/${getUserId()}/locations/${queryString}"), true)?.data
     logDebug("fetchLocations resp = ${resp}")
-    
+
     if(resp)
     {
         setLocations(resp.data)
@@ -197,37 +208,37 @@ def fetchNotifications()
     def queryString = "?limit=1000&sort_direction=ASC&flume_leak=true"
     def resp = httpExec("GET", genParamsMain("users/${getUserId()}/notifications/${queryString}"), true)?.data
     logDebug("fetchNotifications resp = ${resp}")
-    
+
     if(resp?.data)
     {
         def tempCount = getNotifCount() ?: 0
-        
+
         if(resp.data.size() >= tempCount)
         {
-            // this is a typical state; 
+            // this is a typical state;
             //   there are at least as many notifications as we think we already have read
-            
+
             // hack the known ones off of the beginning, then process the rest
             for(i = 0; i < tempCount; i++)
             {
                 resp.data.remove(0)
-            }            
+            }
         }
         else
         {
             // less are in the notification than we think we already have read,
             //  so they must have been cleared in the app
-            
+
             // reset count and process them all to catch up
             tempCount = 0
         }
-        
+
         for(notification in resp.data)
         {
             tempCount++
-            
+
             sendEvent(name: "notificationStream", value: "[${notification.created_datetime}]: ${notification.message}", isStateChange: true)
-            
+
             // short pause to try to keep them sequential in the event log
             pauseExecution(10)
         }
@@ -248,25 +259,35 @@ def getNotifCount()
 def fetchUsageAlerts()
 {
     def tempCount = getAlertCount() ?: 0
-    
+
     def queryString = "?limit=100&offset=${tempCount}&sort_direction=ASC&flume_leak=true"
     def resp = httpExec("GET", genParamsMain("users/${getUserId()}/usage-alerts/${queryString}"), true)?.data
     logDebug("fetchUsageAlerts resp = ${resp}")
-    
+
     if(resp.data)
     {
         for(alert in resp.data)
         {
             tempCount++
-                
-            // check for Flume Smart Leak alerts            
+
+            // check for Flume Smart Leak alerts
             if(true == alert.flume_leak)
             {
                 sendEvent(name: "water", value: "wet")
             }
-        }        
+        }
         setAlertCount(tempCount)
-    }    
+    }
+}
+
+def setLastPollTS()
+{
+    state.lastPollTS = new Date().getTime()
+}
+
+def getLastPollTS()
+{
+    return state.lastPollTS
 }
 
 def setAlertCount(count)
@@ -283,10 +304,10 @@ def queryDevice()
 {
     def now = new Date()
     def wkMult = 7
-    
-    def nowMin, minAgo, hourAgo, yesterday, lastWeek, lastMonth
-    def qMin, qHour, qDay, qWeek, qMonth
-    
+
+    def nowMin, minAgo, hourAgo, yesterday, lastWeek, lastMonth, alertLookback
+    def qMin, qHour, qDay, qWeek, qMonth, qAlertLookback
+
     if(slidingWindow)
     {
         nowMin = now.format('yyyy-MM-dd HH:mm:00')
@@ -295,12 +316,14 @@ def queryDevice()
         yesterday = new Date(now.getTime() - (24 * 60 * 60 * 1000)).format('yyyy-MM-dd HH:mm:00')
         lastWeek = new Date(now.getTime() - (7 * 24 * 60 * 60 * 1000)).format('yyyy-MM-dd HH:mm:00')
         lastMonth = new Date(now.getTime() - ((30 * 24 * 60 * 60 * 1000) & 0xffffffffL)).format('yyyy-MM-dd HH:mm:00')
-        
+        alertLookback = new Date(now.getTime() - (flowAlarmLookback * 60 * 1000)).format('yyyy-MM-dd HH:mm:00')
+
         qMin = [request_id: "lastMin", since_datetime: minAgo, until_datetime: nowMin, bucket: "MIN"]
         qHour = [request_id: "lastHour", since_datetime: hourAgo, until_datetime: nowMin, bucket: "MIN", group_multiplier: 60]
         qDay = [request_id: "lastDay", since_datetime: yesterday, until_datetime: nowMin, bucket: "MIN", group_multiplier: 60 * 24]
         qWeek = [request_id: "lastWeek", since_datetime: lastWeek, until_datetime: nowMin, bucket: "MIN", group_multiplier: 60 * 24 * 7]
         qMonth = [request_id: "lastMonth", since_datetime: lastMonth, until_datetime: nowMin, bucket: "MIN", group_multiplier: 60 * 24 * 30]
+        qAlertLookback = [request_id: "alertLookback", since_datetime: alertLookback, until_datetime: nowMin, bucket: "MIN"]
     }
     else
     {
@@ -310,7 +333,8 @@ def queryDevice()
         hourAgo = new Date(now.getTime()).format('yyyy-MM-dd HH:00:00')
         yesterday = new Date(now.getTime()).format('yyyy-MM-dd 00:00:00')
         lastMonth = new Date(now.getTime()).format('yyyy-MM-01 00:00:00')
-        
+        alertLookback = new Date(now.getTime() - (flowAlarmLookback * 60 * 1000)).format('yyyy-MM-dd HH:mm:00')
+
         // temp value, need to round to Sunday
         def lastWeekRaw = new Date(now.getTime() - (7 * 24 * 60 * 60 * 1000))
         def i = 0
@@ -325,16 +349,17 @@ def queryDevice()
                 found = true
             }
         }
-        
+
         qMin = [request_id: "lastMin", since_datetime: minAgo, until_datetime: nowMin, bucket: "MIN"]
         qHour = [request_id: "lastHour", since_datetime: hourAgo, until_datetime: nowMin, bucket: "HR"]
         qDay = [request_id: "lastDay", since_datetime: yesterday, until_datetime: nowMin, bucket: "DAY"]
         qWeek = [request_id: "lastWeek", since_datetime: lastWeek, until_datetime: nowMin, bucket: "DAY", group_multiplier: wkMult]
         qMonth = [request_id: "lastMonth", since_datetime: lastMonth, until_datetime: nowMin, bucket: "MON"]
+        qAlertLookback = [request_id: "alertLookback", since_datetime: alertLookback, until_datetime: nowMin, bucket: "MIN"]
     }
-    
-    def query = new groovy.json.JsonOutput().toJson([queries: [qMin, qHour, qDay, qWeek, qMonth]])
-    
+
+    def query = new groovy.json.JsonOutput().toJson([queries: [qMin, qHour, qDay, qWeek, qMonth, qAlertLookback]])
+
     def resp = httpExec("POST", genParamsMain("users/${getUserId()}/devices/${getDevices()[0]?.id}/query", query), true)?.data
     if(resp)
     {
@@ -344,6 +369,25 @@ def queryDevice()
         sendEvent(name: "usageLastDay", value: (resp.data[0]?.lastDay && (resp.data[0]?.lastDay?.size() > 0)) ? resp.data[0].lastDay.getAt(resp.data[0].lastDay.size() - 1)?.value?.toFloat().round(2) : "n/a")
         sendEvent(name: "usageLastWeek", value: (resp.data[0]?.lastWeek && (resp.data[0]?.lastWeek?.size() > 0)) ? resp.data[0].lastWeek.getAt(resp.data[0].lastWeek.size() - 1)?.value?.toFloat().round(2) : "n/a")
         sendEvent(name: "usageLastMonth", value: (resp.data[0]?.lastMonth && (resp.data[0]?.lastMonth?.size() > 0)) ? resp.data[0].lastMonth.getAt(resp.data[0].lastMonth.size() - 1)?.value?.toFloat().round(2) : "n/a")
+
+        lastFlowTS = getLastPollTS()
+        setLastPollTS()
+        currentFlowTS = getLastPollTS()
+
+        lookbackFlow = (resp.data[0]?.alertLookback && (resp.data[0]?.alertLookback?.size() > 0) && resp.data[0].alertLookback.getAt(resp.data[0].alertLookback.size() - 1)?.value?.toFloat() > 0) ? true : false
+        pollWindow = (currentFlowTS - lastFlowTS)/60000
+        if(pollWindow <= flowAlarmLookback && lookbackFlow)
+        {
+            continuousFlowReading = device.currentValue("continuousFlowReadings") == null ? 1 : device.currentValue("continuousFlowReadings") + 1
+            sendEvent(name: "continuousFlowReadings", value: continuousFlowReading)
+
+            if (flowAlarmTrigger > 0 && continuousFlowReading >= flowAlarmTrigger) {
+                sendEvent(name: "water", value: "wet")
+            }
+        } else {
+            sendEvent(name: "continuousFlowReadings", value: 0)
+        }
+
     }
 }
 
@@ -366,6 +410,11 @@ def clearAwayMode()
 def clearWetStatus()
 {
     sendEvent(name: "water", value: "dry")
+}
+
+def testWetStatus()
+{
+    sendEvent(name: "water", value: "wet")
 }
 
 def genParamsTokens(op)

--- a/flumeDevice
+++ b/flumeDevice
@@ -18,6 +18,7 @@ limitations under the License.
 
 Change history:
 
+1.2.0 - @cgmckeever - Added user-configurable flow detection and alarming.
 1.1.2 - @robertcraft - Change usage attributes to Number 
 1.1.1 - @tomw - Better handling for notifications when old notifications were deleted by the Flume app.
 1.1.0 - @tomw - Added PresenceSensor to represent away_mode status.
@@ -72,8 +73,8 @@ preferences
     }
     section
     {
-        input "flowAlarmTrigger", "number", title: "Continual readings to trigger alarm. '0' disables trigger.  The lapsed time before alert will be (Refresh Interval) * ThisValue", defaultValue: 45, required: true
-        input "flowAlarmLookback", "number", title: "Number of minutes to look back to indicated flow occurred.", defaultValue: 5, required: true
+        input "flowAlarmTrigger", "number", title: "Count of consecutive flow readings to trigger alarm (0 to disable).  Note: one reading per refresh interval when flow is detected.", defaultValue: 45, required: true
+        input "flowAlarmLookback", "number", title: "How many minutes to look back to identify a consecutive flow reading?", defaultValue: 5, required: true
     }
     section
     {

--- a/flumeDevice
+++ b/flumeDevice
@@ -90,6 +90,13 @@ def logDebug(msg)
     }
 }
 
+def errorLine(error)
+{
+    String str= error.getStackTrace().toString()
+    def pattern = ( str =~ /groovy.(\d+)./  )
+    return pattern[0][1]
+}
+
 def updated()
 {
     configure()
@@ -115,7 +122,8 @@ def configure()
     }
     catch (Exception e)
     {
-        logDebug("error: ${e.message}")
+        errorLine = errorLine(e)
+        log.error("error: ${e.message} @ Line: ${errorLine}")
         //logDebug("status = ${e.getResponse()?.getStatus()}")
 
         sendEvent(name: "commStatus", value: "error")
@@ -153,7 +161,8 @@ def refresh()
     }
     catch (Exception e)
     {
-        log.error("error: ${e.message}")
+        errorLine = errorLine(e)
+        log.error("error: ${e.message} @ Line: ${errorLine}")
         //log.error("status = ${e.getResponse()?.getStatus()}")
 
         sendEvent(name: "commStatus", value: "error")
@@ -288,7 +297,8 @@ def setLastPollTS()
 
 def getLastPollTS()
 {
-    return state.lastPollTS
+    lastPoll = state.lastPollTS == null ? 0 : state.lastPollTS.toInteger()
+    return lastPoll
 }
 
 def setAlertCount(count)
@@ -309,32 +319,32 @@ def queryDevice()
     def nowMin, minAgo, hourAgo, yesterday, lastWeek, lastMonth, alertLookback
     def qMin, qHour, qDay, qWeek, qMonth, qAlertLookback
 
+    nowMin = now.format('yyyy-MM-dd HH:mm:00')
+
+    alertLookback = new Date(now.getTime() - (flowAlarmLookback * 60 * 1000)).format('yyyy-MM-dd HH:mm:00')
+    qAlertLookback = [request_id: "alertLookback", since_datetime: alertLookback, until_datetime: nowMin, bucket: "MIN", group_multiplier: flowAlarmLookback]
+
     if(slidingWindow)
     {
-        nowMin = now.format('yyyy-MM-dd HH:mm:00')
         minAgo = new Date(now.getTime() - (60 * 1000)).format('yyyy-MM-dd HH:mm:00')
         hourAgo = new Date(now.getTime() - (60 * 60 * 1000)).format('yyyy-MM-dd HH:mm:00')
         yesterday = new Date(now.getTime() - (24 * 60 * 60 * 1000)).format('yyyy-MM-dd HH:mm:00')
         lastWeek = new Date(now.getTime() - (7 * 24 * 60 * 60 * 1000)).format('yyyy-MM-dd HH:mm:00')
         lastMonth = new Date(now.getTime() - ((30 * 24 * 60 * 60 * 1000) & 0xffffffffL)).format('yyyy-MM-dd HH:mm:00')
-        alertLookback = new Date(now.getTime() - (flowAlarmLookback * 60 * 1000)).format('yyyy-MM-dd HH:mm:00')
 
         qMin = [request_id: "lastMin", since_datetime: minAgo, until_datetime: nowMin, bucket: "MIN"]
         qHour = [request_id: "lastHour", since_datetime: hourAgo, until_datetime: nowMin, bucket: "MIN", group_multiplier: 60]
         qDay = [request_id: "lastDay", since_datetime: yesterday, until_datetime: nowMin, bucket: "MIN", group_multiplier: 60 * 24]
         qWeek = [request_id: "lastWeek", since_datetime: lastWeek, until_datetime: nowMin, bucket: "MIN", group_multiplier: 60 * 24 * 7]
         qMonth = [request_id: "lastMonth", since_datetime: lastMonth, until_datetime: nowMin, bucket: "MIN", group_multiplier: 60 * 24 * 30]
-        qAlertLookback = [request_id: "alertLookback", since_datetime: alertLookback, until_datetime: nowMin, bucket: "MIN"]
     }
     else
     {
-        nowMin = now.format('yyyy-MM-dd HH:mm:00')
         // MIN doesn't respond for a minute in progress, so go one minute ago for real
         minAgo = new Date(now.getTime() - 60000).format('yyyy-MM-dd HH:mm:00')
         hourAgo = new Date(now.getTime()).format('yyyy-MM-dd HH:00:00')
         yesterday = new Date(now.getTime()).format('yyyy-MM-dd 00:00:00')
         lastMonth = new Date(now.getTime()).format('yyyy-MM-01 00:00:00')
-        alertLookback = new Date(now.getTime() - (flowAlarmLookback * 60 * 1000)).format('yyyy-MM-dd HH:mm:00')
 
         // temp value, need to round to Sunday
         def lastWeekRaw = new Date(now.getTime() - (7 * 24 * 60 * 60 * 1000))
@@ -356,7 +366,6 @@ def queryDevice()
         qDay = [request_id: "lastDay", since_datetime: yesterday, until_datetime: nowMin, bucket: "DAY"]
         qWeek = [request_id: "lastWeek", since_datetime: lastWeek, until_datetime: nowMin, bucket: "DAY", group_multiplier: wkMult]
         qMonth = [request_id: "lastMonth", since_datetime: lastMonth, until_datetime: nowMin, bucket: "MON"]
-        qAlertLookback = [request_id: "alertLookback", since_datetime: alertLookback, until_datetime: nowMin, bucket: "MIN"]
     }
 
     def query = new groovy.json.JsonOutput().toJson([queries: [qMin, qHour, qDay, qWeek, qMonth, qAlertLookback]])


### PR DESCRIPTION
# Issue

The Flume leak detection algorithm has two limitations
- The alerting time currently can not be less than 2 hours for detection
- In those 2 hours, there needs to be continual flow recorded every other minute (ie 60 readings total 2 min apart)

This seems limited. Lets fix this!

# Discovery

Out of curiosity, I ran a series of slow leak tests. These were about .02 GPM -- which seems small, but not when you [watch this video ](https://photos.app.goo.gl/vc5Gp5bu1uafQReDA)[Thats 45ml (.01 gallon) in ~30s]. Thats a decent leak, you wouldn't want that to go undetected too long behind a wall.

Unfortunately (at least my meter/detector) only catches this flow every other minute. Which should be OK, until it misses a couple detections . **Note:** 2:21 - One more than 2 min reading invalidated the detection.

<img width="1161" alt="Screen Shot 2022-01-24 at 3 36 19 PM" src="https://user-images.githubusercontent.com/513738/151019131-ef16760f-ac07-4b6b-97b0-2204d7a42810.png">

# Solution

Enabling a flowLookback, we can increase the 2 min limitation to whatever we want. Thus, for each API poll, we can also look back X minutes (`flowAlarmLookback`)  and see if there was flow, if so we tick up. the `continuousFlowReadings`. 

The `status` will be `wet` after the number of continuation readings surpasses the defined threshold (`flowAlarmTrigger`). If this value is set to 0, there will be no automated status change by the driver. However, the `continuousFlowReadings` will continue to be ticked with observed flow and other rules can be created via Hubitat.

# Additionally

- a `lastPollTS` was created to determine if polling intervals fall inside this limit, and also helps with [open issue](https://github.com/tomwpublic/hubitat_flume/issues/6) 
- A `Test Wet Status` command was added -- I wanted to see this alert work in HomeKit



