### PR TITLE
based flow detection on time not ticks

### DIFF
--- a/flumeDevice
+++ b/flumeDevice
@@ -18,6 +18,7 @@ limitations under the License.
 
 Change history:
 
+1.2.1 - cgmckeever - refine flow-detection.
 1.2.0 - cgmckeever - Added user-configurable flow detection and alarming.
 1.1.2 - robertcraft - Change usage attributes to Number 
 1.1.1 - tomw - Better handling for notifications when old notifications were deleted by the Flume app.
@@ -51,7 +52,9 @@ metadata
         attribute "usageLastWeek", "number"
         attribute "usageLastMonth", "number"
 
-        attribute "continuousFlowReadings", "number"
+        attribute "flowDurationDetail", "string"
+        attribute "flowDurationMin", "number"
+        attribute "flowStatus", "string"
 
         attribute "notificationStream", "string"
     }
@@ -73,8 +76,8 @@ preferences
     }
     section
     {
-        input "flowAlarmTrigger", "number", title: "Count of consecutive flow readings to trigger alarm (0 to disable).  Note: one reading per refresh interval when flow is detected.", defaultValue: 45, required: true
-        input "flowAlarmLookback", "number", title: "How many minutes to look back to identify a consecutive flow reading?", defaultValue: 5, required: true
+        input "flowAlarmTriggerTime", "number", title: "Number of minutes where flow is observed to trigger alert (0 to disable).", defaultValue: 60, required: true
+        input "flowAlarmLookback", "number", title: "Number of minutes to look back to identify a consecutive flow reading", defaultValue: 3, required: true
     }
     section
     {
@@ -283,7 +286,7 @@ def fetchUsageAlerts()
             // check for Flume Smart Leak alerts
             if(true == alert.flume_leak)
             {
-                sendEvent(name: "water", value: "wet")
+                setWetStatus()
             }
         }
         setAlertCount(tempCount)
@@ -297,8 +300,19 @@ def setLastPollTS()
 
 def getLastPollTS()
 {
-    lastPoll = state.lastPollTS == null ? 0 : state.lastPollTS.toInteger()
+    lastPoll = state.lastPollTS == null ? 0 : state.lastPollTS.toLong()
     return lastPoll
+}
+
+def setFlowDetectedTS()
+{
+    state.flowDetectedTS = getLastPollTS()
+}
+
+def getFlowDetectedTS()
+{
+    flowDetectedTS = state.flowDetectedTS == null ? 0 : state.flowDetectedTS.toLong()
+    return flowDetectedTS
 }
 
 def setAlertCount(count)
@@ -316,20 +330,21 @@ def queryDevice()
     def now = new Date()
     def wkMult = 7
 
-    def nowMin, minAgo, hourAgo, yesterday, lastWeek, lastMonth, alertLookback
-    def qMin, qHour, qDay, qWeek, qMonth, qAlertLookback
+    def nowMin, minAgo, hourAgo, yesterday, lastWeek, lastMonth, flowLookback
+    def qMin, qHour, qDay, qWeek, qMonth, qFlowLookback
 
     nowMin = now.format('yyyy-MM-dd HH:mm:00')
+    // MIN doesn't respond for a minute in progress, so go one minute ago for real
+    minAgo = new Date(now.getTime() - 60000).format('yyyy-MM-dd HH:mm:00')
 
     // make sure to check for missing setting (pre-1.2.0 update)
     flowAlarmLookback = flowAlarmLookback ?: 5
     
-    alertLookback = new Date(now.getTime() - (flowAlarmLookback * 60 * 1000)).format('yyyy-MM-dd HH:mm:00')
-    qAlertLookback = [request_id: "alertLookback", since_datetime: alertLookback, until_datetime: nowMin, bucket: "MIN", group_multiplier: flowAlarmLookback]
+    flowLookback = new Date(now.getTime() - (flowAlarmLookback * 60 * 1000)).format('yyyy-MM-dd HH:mm:00')
+    qFlowLookback = [request_id: "flowLookback", since_datetime: flowLookback, until_datetime: nowMin, bucket: "MIN", group_multiplier: flowAlarmLookback]
 
     if(slidingWindow)
     {
-        minAgo = new Date(now.getTime() - (60 * 1000)).format('yyyy-MM-dd HH:mm:00')
         hourAgo = new Date(now.getTime() - (60 * 60 * 1000)).format('yyyy-MM-dd HH:mm:00')
         yesterday = new Date(now.getTime() - (24 * 60 * 60 * 1000)).format('yyyy-MM-dd HH:mm:00')
         lastWeek = new Date(now.getTime() - (7 * 24 * 60 * 60 * 1000)).format('yyyy-MM-dd HH:mm:00')
@@ -343,8 +358,6 @@ def queryDevice()
     }
     else
     {
-        // MIN doesn't respond for a minute in progress, so go one minute ago for real
-        minAgo = new Date(now.getTime() - 60000).format('yyyy-MM-dd HH:mm:00')
         hourAgo = new Date(now.getTime()).format('yyyy-MM-dd HH:00:00')
         yesterday = new Date(now.getTime()).format('yyyy-MM-dd 00:00:00')
         lastMonth = new Date(now.getTime()).format('yyyy-MM-01 00:00:00')
@@ -371,7 +384,7 @@ def queryDevice()
         qMonth = [request_id: "lastMonth", since_datetime: lastMonth, until_datetime: nowMin, bucket: "MON"]
     }
 
-    def query = new groovy.json.JsonOutput().toJson([queries: [qMin, qHour, qDay, qWeek, qMonth, qAlertLookback]])
+    def query = new groovy.json.JsonOutput().toJson([queries: [qMin, qHour, qDay, qWeek, qMonth, qFlowLookback]])
 
     def resp = httpExec("POST", genParamsMain("users/${getUserId()}/devices/${getDevices()[0]?.id}/query", query), true)?.data
     if(resp)
@@ -383,25 +396,35 @@ def queryDevice()
         sendEvent(name: "usageLastWeek", value: (resp.data[0]?.lastWeek && (resp.data[0]?.lastWeek?.size() > 0)) ? resp.data[0].lastWeek.getAt(resp.data[0].lastWeek.size() - 1)?.value?.toFloat().round(2) : "n/a")
         sendEvent(name: "usageLastMonth", value: (resp.data[0]?.lastMonth && (resp.data[0]?.lastMonth?.size() > 0)) ? resp.data[0].lastMonth.getAt(resp.data[0].lastMonth.size() - 1)?.value?.toFloat().round(2) : "n/a")
 
-        lastFlowTS = getLastPollTS()
         setLastPollTS()
         currentFlowTS = getLastPollTS()
 
-        lookbackFlow = (resp.data[0]?.alertLookback && (resp.data[0]?.alertLookback?.size() > 0) && resp.data[0].alertLookback.getAt(resp.data[0].alertLookback.size() - 1)?.value?.toFloat() > 0) ? true : false
-        pollWindow = (currentFlowTS - lastFlowTS)/60000
-        if(pollWindow <= flowAlarmLookback && lookbackFlow)
-        {
-            continuousFlowReading = device.currentValue("continuousFlowReadings") == null ? 1 : device.currentValue("continuousFlowReadings") + 1
-            sendEvent(name: "continuousFlowReadings", value: continuousFlowReading)
+        lookbackFlow = (resp.data[0]?.flowLookback && (resp.data[0]?.flowLookback?.size() > 0) && resp.data[0].flowLookback.getAt(resp.data[0].flowLookback.size() - 1)?.value?.toFloat() > 0) ? true : false
 
-            if (flowAlarmTrigger > 0 && continuousFlowReading >= flowAlarmTrigger)
-            {
-                sendEvent(name: "water", value: "wet")
+        flowStatus = device.currentValue("flowStatus")
+        flowDetectedTS = getFlowDetectedTS()
+
+        if (lookbackFlow) {
+            if (flowStatus == "stopped") {
+                sendEvent(name: "flowStatus", value: "running")
+                setFlowDetectedTS()
+                flowDetectedTS = getFlowDetectedTS()
             }
-        }
-        else
-        {
-            sendEvent(name: "continuousFlowReadings", value: 0)
+            runTime = Math.round((currentFlowTS - flowDetectedTS)/600)/100
+            sendEvent(name: "flowDurationDetail", value: "Running for " + runTime.toString() + " min")
+            sendEvent(name: "flowDurationMin", value: runTime)
+
+            if (flowAlarmTriggerTime > 0 && runTime >= flowAlarmTriggerTime)
+            {
+                sendWetStatus()
+            }
+        } else {
+            if (flowStatus == "running") {
+                runTime = Math.round((currentFlowTS - flowDetectedTS)/600)/100
+                sendEvent(name: "flowDurationDetail", value: "Ran " + runTime + " min")
+                sendEvent(name: "flowDurationMin", value: 0)
+                sendEvent(name: "flowStatus", value: "stopped")
+            }
         }
     }
 }
@@ -422,6 +445,11 @@ def clearAwayMode()
     setAwayMode(false)
 }
 
+def setWetStatus()
+{
+    sendEvent(name: "water", value: "wet")
+}
+
 def clearWetStatus()
 {
     sendEvent(name: "water", value: "dry")
@@ -429,7 +457,7 @@ def clearWetStatus()
 
 def testWetStatus()
 {
-    sendEvent(name: "water", value: "wet")
+    setWetStatus()
 }
 
 def genParamsTokens(op)

--- a/flumeDevice
+++ b/flumeDevice
@@ -76,7 +76,7 @@ preferences
     }
     section
     {
-        input "flowAlarmTriggerTime", "number", title: "Number of minutes where flow is observed to trigger alert (0 to disable).", defaultValue: 60, required: true
+        input "flowAlarmTriggerTime", "number", title: "Number of minutes where flow is observed to trigger alert (0 to disable).", defaultValue: 90, required: true
         input "flowAlarmLookback", "number", title: "Number of minutes to look back to identify a consecutive flow reading", defaultValue: 3, required: true
     }
     section
@@ -330,18 +330,21 @@ def queryDevice()
     def now = new Date()
     def wkMult = 7
 
-    def nowMin, minAgo, hourAgo, yesterday, lastWeek, lastMonth, flowLookback
-    def qMin, qHour, qDay, qWeek, qMonth, qFlowLookback
+    def nowMin, minAgo, hourAgo, yesterday, lastWeek, lastMonth, flowLookback, flowRefresh
+    def qMin, qHour, qDay, qWeek, qMonth, qFlowLookback, qFlowRefresh
 
     nowMin = now.format('yyyy-MM-dd HH:mm:00')
-    // MIN doesn't respond for a minute in progress, so go one minute ago for real
+    // `MIN` queries don't contain results for the current minute; request the previous full minute
     minAgo = new Date(now.getTime() - 60000).format('yyyy-MM-dd HH:mm:00')
 
     // make sure to check for missing setting (pre-1.2.0 update)
     flowAlarmLookback = flowAlarmLookback ?: 5
     
     flowLookback = new Date(now.getTime() - (flowAlarmLookback * 60 * 1000)).format('yyyy-MM-dd HH:mm:00')
+    flowRefresh = new Date(now.getTime() - (refreshInterval * 60 * 1000)).format('yyyy-MM-dd HH:mm:00')
+
     qFlowLookback = [request_id: "flowLookback", since_datetime: flowLookback, until_datetime: nowMin, bucket: "MIN", group_multiplier: flowAlarmLookback]
+    qFlowRefresh = [request_id: "flowRefresh", since_datetime: flowRefresh, until_datetime: nowMin, bucket: "MIN", group_multiplier: refreshInterval]
 
     if(slidingWindow)
     {
@@ -384,7 +387,7 @@ def queryDevice()
         qMonth = [request_id: "lastMonth", since_datetime: lastMonth, until_datetime: nowMin, bucket: "MON"]
     }
 
-    def query = new groovy.json.JsonOutput().toJson([queries: [qMin, qHour, qDay, qWeek, qMonth, qFlowLookback]])
+    def query = new groovy.json.JsonOutput().toJson([queries: [qMin, qHour, qDay, qWeek, qMonth, qFlowLookback, qFlowRefresh]])
 
     def resp = httpExec("POST", genParamsMain("users/${getUserId()}/devices/${getDevices()[0]?.id}/query", query), true)?.data
     if(resp)
@@ -396,34 +399,57 @@ def queryDevice()
         sendEvent(name: "usageLastWeek", value: (resp.data[0]?.lastWeek && (resp.data[0]?.lastWeek?.size() > 0)) ? resp.data[0].lastWeek.getAt(resp.data[0].lastWeek.size() - 1)?.value?.toFloat().round(2) : "n/a")
         sendEvent(name: "usageLastMonth", value: (resp.data[0]?.lastMonth && (resp.data[0]?.lastMonth?.size() > 0)) ? resp.data[0].lastMonth.getAt(resp.data[0].lastMonth.size() - 1)?.value?.toFloat().round(2) : "n/a")
 
+        lookbackFlow = (resp.data[0]?.flowLookback && (resp.data[0]?.flowLookback?.size() > 0) && resp.data[0].flowLookback.getAt(resp.data[0].flowLookback.size() - 1)?.value?.toFloat() > 0) ? true : false
+        refreshFlow = (resp.data[0]?.flowRefresh && (resp.data[0]?.flowRefresh?.size() > 0) && resp.data[0].flowRefresh.getAt(resp.data[0].flowRefresh.size() - 1)?.value?.toFloat() > 0) ? true : false
+
         setLastPollTS()
         currentFlowTS = getLastPollTS()
-
-        lookbackFlow = (resp.data[0]?.flowLookback && (resp.data[0]?.flowLookback?.size() > 0) && resp.data[0].flowLookback.getAt(resp.data[0].flowLookback.size() - 1)?.value?.toFloat() > 0) ? true : false
-
-        flowStatus = device.currentValue("flowStatus")
         flowDetectedTS = getFlowDetectedTS()
+        flowStatus = device.currentValue("flowStatus")
 
-        if (lookbackFlow) {
-            if (flowStatus == "stopped") {
-                sendEvent(name: "flowStatus", value: "running")
+        if (refreshFlow || lookbackFlow)
+        {
+            // [cgmckeever] future us, this `flowDetectedTS == 0` is an edge case
+            //              where water is flowing and preferences are saved.
+            //              `flowDetectedTS` state variable gets purged,
+            //              making runTime very large, and usually triggers an alert
+            if (flowStatus == "stopped" || flowDetectedTS == 0 )
+            {
                 setFlowDetectedTS()
                 flowDetectedTS = getFlowDetectedTS()
+                logDebug(">>>>>>>>>>>>> startFlowWatch: ${flowDetectedTS}")
             }
+
+            if (refreshFlow)
+            {
+                status = "running"
+            } else
+            {
+                status = "monitoring"
+            }
+
+            if (flowStatus != status)
+            {
+                sendEvent(name: "flowStatus", value: status)
+            }
+
             runTime = Math.round((currentFlowTS - flowDetectedTS)/600)/100
-            sendEvent(name: "flowDurationDetail", value: "Running for " + runTime.toString() + " min")
+            sendEvent(name: "flowDurationDetail", value: status + " for " + runTime.toString() + " min")
             sendEvent(name: "flowDurationMin", value: runTime)
 
             if (flowAlarmTriggerTime > 0 && runTime >= flowAlarmTriggerTime)
             {
-                sendWetStatus()
+                setWetStatus()
             }
-        } else {
-            if (flowStatus == "running") {
+        } else
+        {
+            if (flowStatus != "stopped")
+            {
                 runTime = Math.round((currentFlowTS - flowDetectedTS)/600)/100
-                sendEvent(name: "flowDurationDetail", value: "Ran " + runTime + " min")
+                sendEvent(name: "flowDurationDetail", value: "Ran " + (runTime - (flowAlarmLookback - refreshInterval)).toString() + " min")
                 sendEvent(name: "flowDurationMin", value: 0)
                 sendEvent(name: "flowStatus", value: "stopped")
+                logDebug(">>>>>>>>>>>>> endFlowWatch: ${currentFlowTS}")
             }
         }
     }


### PR DESCRIPTION
You might kill me .... 
But the whole concept of `ticks` is gone and you and I will never get those 2 hours of conversation time back.

Using both our ideas, its just checking if the lookback has `any` flow and then checking if the first observed flow time is greater than the `triggerTime`

I think for future-us this does make all the logic more clear.

I could not think of WHY a tick count would be useful at this stage, even using the concept of increase the tick on on NEW flow observation, but still continuing to identify overall flow based on the lookback window.

Adding it in would be 3 lines of code ... but I can not think of the reason why its important

# No Water flow detected

<img width="295" alt="Screen Shot 2022-01-27 at 7 28 08 PM" src="https://user-images.githubusercontent.com/513738/151471091-1f77e7f5-6b91-468a-af7e-78212cd49ff2.png">

# Running Water 
 - Flow detected during refreshInterval

<img width="289" alt="Screen Shot 2022-01-27 at 7 22 43 PM" src="https://user-images.githubusercontent.com/513738/151470633-d64d9456-fe64-4b13-8dec-de381bfe63a2.png">

# Monitoring to watch lookback
- Flow outside of refreshInterval but in lookback window

<img width="298" alt="Screen Shot 2022-01-27 at 7 25 27 PM" src="https://user-images.githubusercontent.com/513738/151470821-996edf32-d419-4bf4-861c-eec9047e8e4c.png">

